### PR TITLE
fix `nix flake check` and `show`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -99,8 +99,8 @@
       hydraJobs = self.packages.${evalSystem};
     });
   in flake inputs // {
-    hydraJobs = { nixpkgs ? inputs.nixpkgs, flake-utils ? inputs.flake-utils, haskell-nix ? inputs.haskell-nix }@overrides: let
-      flake' = flake (inputs // overrides // { self = flake'; });
+    hydraJobs = let
+      flake' = flake (inputs // { self = flake'; });
       evalSystem = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${evalSystem};
     in flake'.hydraJobs // {


### PR DESCRIPTION
Closes: https://github.com/input-output-hk/cicero-pipe/issues/1

`nix flake check` and `show` succeed now. However, is this PR a step backwards in regard to https://github.com/NixOS/nix/issues/7031#issue-1371325374 ?