### PR TITLE
check in `.envrc`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 dist-newstyle
+.direnv
+result*


### PR DESCRIPTION
consistent with https://github.com/input-output-hk/haskell.nix/blob/master/.envrc and https://github.com/input-output-hk/haskell.nix/blob/master/.gitignore